### PR TITLE
use 'inherits' module rather than util.inherits

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var stream = require('stream')
-var util = require('util')
+var inherits = require('inherits')
 var gen = require('generate-object-property')
 
 var quote = new Buffer('"')[0]
@@ -30,7 +30,7 @@ var Parser = function(opts) {
   }
 }
 
-util.inherits(Parser, stream.Transform)
+inherits(Parser, stream.Transform)
 
 Parser.prototype._transform = function(data, enc, cb) {
   var start = 0

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "generate-object-property": "^1.0.0",
     "ldjson-stream": "^1.1.0",
-    "minimist": "^0.2.0"
+    "minimist": "^0.2.0",
+    "inherits": "^2.0.1"
   },
   "devDependencies": {
     "bops": "^0.1.1",


### PR DESCRIPTION
From the readme of isaacs' [`inherits`](https://www.npmjs.org/package/inherits) module:

> This package exports standard inherits from node.js util module in node environment, but also provides alternative browser-friendly implementation through browser field. Alternative implementation is a literal copy of standard one located in standalone module to avoid requiring of util. It also has a shim for old browsers with no Object.create support.
> 
> While keeping you sure you are using standard inherits implementation in node.js environment, it allows bundlers such as browserify to not include full util package to your client code if all you need is just inherits function. It worth, because browser shim for util package is large and inherits is often the single function you need from it.
> 
> It's recommended to use this package instead of require('util').inherits for any code that has chances to be used not only in node.js but in browser too.
