### PR TITLE
examples: add `transform` example

### DIFF
--- a/examples/transform.js
+++ b/examples/transform.js
@@ -1,0 +1,27 @@
+const write = require('csv-write-stream')
+const through = require('through2')
+const parse = require('../')
+const path = require('path')
+const fs = require('fs')
+
+// Read a file, transform it and send it
+// to stdout. Optionally could also write
+// to a file instead of stdout with:
+// .pipe(fs.createWriteStream('./file'))
+fs.createReadStream(path.join(__dirname, '../test/data/dummy.csv'))
+  .pipe(parse())
+  .pipe(through.obj(transform))
+  .pipe(write())
+  .pipe(process.stdout)
+
+// Prepend all chunks with `value: `.
+// @param {Object} chunk
+// @param {String} encoding
+// @param {Function} callback
+function transform (chunk, enc, cb) {
+  Object.keys(chunk).forEach(function(k) {
+    chunk[k] = 'value: ' + chunk[k]
+  })
+  this.push(chunk)
+  cb()
+}


### PR DESCRIPTION
Adds a simple example showing how to read a file, transform it and then pipe it back out. Took me a while to figure out how `csv-parser` and `csv-write-stream` can work together. Figured this might help other stream beginners get started. Thanks!