### PR TITLE
auto-detect CR and NL newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var genfun = require('generate-function')
 var quote = new Buffer('"')[0]
 var comma = new Buffer(',')[0]
 var cr = new Buffer('\r')[0]
+var nl = new Buffer('\n')[0]
 
 var Parser = function(opts) {
   if (!opts) opts = {}
@@ -18,7 +19,7 @@ var Parser = function(opts) {
     this.newline = new Buffer(opts.newline)[0]
     this.customNewline = true
   } else {
-    this.newline = new Buffer('\n')[0]
+    this.newline = nl
     this.customNewline = false
   }
 
@@ -54,10 +55,21 @@ Parser.prototype._transform = function(data, enc, cb) {
 
   for (var i = start; i < buf.length; i++) {
     if (buf[i] === quote) this._quoting = !this._quoting
+    if (!this._quoting) {
+      if (this._first && !this.customNewline) {
+        if (buf[i] === nl) {
+          this.newline = nl;
+        } else if (buf[i] === cr) {
+          if (buf[i+1] !== nl) {
+            this.newline = cr;
+          }
+        }
+      }
 
-    if (!this._quoting && buf[i] === this.newline) {
-      this._online(buf, this._prevEnd, i+1)
-      this._prevEnd = i+1
+      if (buf[i] === this.newline) {
+        this._online(buf, this._prevEnd, i+1)
+        this._prevEnd = i+1
+      }
     }
   }
 


### PR DESCRIPTION
This PR auto-detect files that lines are separated by `\r`.
Detection of the other newlines is still fine: `\n` and `\r\n`.

This fixes https://github.com/mafintosh/csv-parser/issues/11
The extra test for a csv file with CR as newlines is here: https://github.com/maxogden/csv-spectrum/pull/10
I manually pulled @finnp newlinecr branch for csv-spectrum and all 54+1 tests are passing.