### PR TITLE
Ignore test and examples in the npm module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test/
+examples/
+.travis.yml


### PR DESCRIPTION
It makes the tarred-gzipped module smaller by a factor of 69: from 331K to 4.8K

Not sure if anybody cared. One of my team mates actually felt strongly about it: after our own efforts to not package csv files in our own codebase we could still find those hanging in there.

Thanks again for all the csv-* modules!