### PR TITLE
add `neat-csv` to related in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ For example, to produce an object with a JSON array of items as output:
 --beforeOutput='{"items":[' --afterOutput=]} --outputSeparator=,
 ```
 
+## Related
+
+- [neat-csv](https://github.com/sindresorhus/neat-csv) - Promise convenience wrapper
+
 ## License
 
 MIT


### PR DESCRIPTION
Since I mostly just work on buffered CSV's, I wrote a simple wrapper that accepts a buffer/string/stream and returns a promise for the buffered output.

No worries if you don't want this though.

https://github.com/sindresorhus/neat-csv