### PR TITLE
Adds supports for skipped headers and header transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ var Parser = function (opts) {
 
   this.headers = opts.headers || null
   this.strict = opts.strict || null
+  this.transformHeaders = opts.transformHeaders || function (id) { return id }
 
   this._raw = !!opts.raw
   this._prev = null
@@ -166,8 +167,12 @@ Parser.prototype._compile = function () {
 
   var Row = genfun()('function Row (cells) {')
 
+  var self = this
   this.headers.forEach(function (cell, i) {
-    Row('%s = cells[%d]', genobj('this', cell), i)
+    var newHeader = self.transformHeaders(cell, i)
+    if (newHeader) {
+      Row('%s = cells[%d]', genobj('this', newHeader), i)
+    }
   })
 
   Row('}')

--- a/index.js
+++ b/index.js
@@ -27,7 +27,12 @@ var Parser = function (opts) {
 
   this.headers = opts.headers || null
   this.strict = opts.strict || null
-  this.transformHeaders = opts.transformHeaders || function (id) { return id }
+
+  function defaultMapHeaders (id) {
+    return id
+  }
+
+  this.mapHeaders = opts.mapHeaders || defaultMapHeaders
 
   this._raw = !!opts.raw
   this._prev = null
@@ -169,7 +174,7 @@ Parser.prototype._compile = function () {
 
   var self = this
   this.headers.forEach(function (cell, i) {
-    var newHeader = self.transformHeaders(cell, i)
+    var newHeader = self.mapHeaders(cell, i)
     if (newHeader) {
       Row('%s = cells[%d]', genobj('this', newHeader), i)
     }

--- a/test/test.js
+++ b/test/test.js
@@ -300,9 +300,9 @@ test('process all rows', function (t) {
 })
 
 test('skip columns a and c', function (t) {
-  collect('dummy.csv', {transformHeaders: transformHeaders}, verify)
-  function transformHeaders (name, i) {
-    if (['a', 'c'].includes(name)) {
+  collect('dummy.csv', {mapHeaders: mapHeaders}, verify)
+  function mapHeaders (name, i) {
+    if (['a', 'c'].indexOf(name) > -1) {
       return null
     }
     return name
@@ -316,8 +316,8 @@ test('skip columns a and c', function (t) {
 })
 
 test('rename columns', function (t) {
-  collect('dummy.csv', {transformHeaders: transformHeaders}, verify)
-  function transformHeaders (name, i) {
+  collect('dummy.csv', {mapHeaders: mapHeaders}, verify)
+  function mapHeaders (name, i) {
     var headers = {a: 'x', b: 'y', c: 'z'}
     return headers[name]
   }

--- a/test/test.js
+++ b/test/test.js
@@ -299,6 +299,36 @@ test('process all rows', function (t) {
   }
 })
 
+test('skip columns a and c', function (t) {
+  collect('dummy.csv', {transformHeaders: transformHeaders}, verify)
+  function transformHeaders (name, i) {
+    if (['a', 'c'].includes(name)) {
+      return null
+    }
+    return name
+  }
+  function verify (err, lines) {
+    t.false(err, 'no err')
+    t.same(lines[0], {b: '2'}, 'first row')
+    t.equal(lines.length, 1, '1 row')
+    t.end()
+  }
+})
+
+test('rename columns', function (t) {
+  collect('dummy.csv', {transformHeaders: transformHeaders}, verify)
+  function transformHeaders (name, i) {
+    var headers = {a: 'x', b: 'y', c: 'z'}
+    return headers[name]
+  }
+  function verify (err, lines) {
+    t.false(err, 'no err')
+    t.same(lines[0], {x: '1', y: '2', z: '3'}, 'first row')
+    t.equal(lines.length, 1, '1 row')
+    t.end()
+  }
+})
+
 // helpers
 
 function fixture (name) {


### PR DESCRIPTION
This PR just add two features that I needed:

- support for custom headers: it applies a custom function to the header to transform them (for instance replace spaces with underscores etc. ;
- support for skipped columns: it uses the above function, if for a given header the `transformHeaders` function returns a false value your column will not be included in the record.

I am open to suggestions in order to merge.

It could help to support the `--only-parse=...` option (#12).