### PR TITLE
Adds option `remove` to remove headers from output

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -40,6 +40,7 @@ if (argv.help || (process.stdin.isTTY && !filename)) {
     '  --escape,-e         Set the escape character (defaults to quote value)\n' +
     '  --strict            Require column length match headers length\n' +
     '  --version,-v        Print out the installed version\n' +
+    '  --remove            Remove headers from output\n' +
     '  --help              Show this help\n'
   )
   process.exit(1)
@@ -47,6 +48,11 @@ if (argv.help || (process.stdin.isTTY && !filename)) {
 
 var input
 var output = (argv.output && argv.output !== '-') ? fs.createWriteStream(argv.output) : process.stdout
+var removedHeaders = argv.remove && argv.remove.split(',')
+
+function mapHeaders (name, i) {
+  return removedHeaders.indexOf(name) === -1 ? name : null
+}
 
 if (filename === '-' || !filename) {
   input = process.stdin
@@ -61,7 +67,8 @@ input
   .pipe(csv({
     headers: headers,
     separator: argv.separator,
-    strict: argv.strict
+    strict: argv.strict,
+    mapHeaders: argv.remove ? mapHeaders : null
   }))
   .pipe(ndjson.serialize())
   .pipe(output)


### PR DESCRIPTION
Just adds an option to remove the headers from the output. For instance:

     node bin.js --remove=a,b source.csv

will remove the headers `a` and `b` from the output of the `source.csv` file.

It makes more sense to me to remove headers than to keep them, but I am open to discuss about it.