### PR TITLE
Support for the max option to parse only a number of rows

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -39,6 +39,7 @@ if (argv.help || (process.stdin.isTTY && !filename)) {
     '  --quote,-q          Set the quote character (\'"\' by default)\n' +
     '  --escape,-e         Set the escape character (defaults to quote value)\n' +
     '  --strict            Require column length match headers length\n' +
+    '  --max,-m            Stop parsing after a number of rows\n' +
     '  --version,-v        Print out the installed version\n' +
     '  --help              Show this help\n'
   )
@@ -60,6 +61,7 @@ if (filename === '-' || !filename) {
 input
   .pipe(csv({
     headers: headers,
+    max: argv.maxrows,
     separator: argv.separator,
     strict: argv.strict
   }))

--- a/test/test.js
+++ b/test/test.js
@@ -299,6 +299,15 @@ test('process all rows', function (t) {
   }
 })
 
+test('process only 250 rows', function (t) {
+  collect('process_all_rows.csv', { max: 250 }, verify)
+  function verify (err, lines) {
+    t.false(err, 'no err')
+    t.equal(lines.length, 250, '250 rows')
+    t.end()
+  }
+})
+
 test('skip columns a and c', function (t) {
   collect('dummy.csv', {mapHeaders: mapHeaders}, verify)
   function mapHeaders (name, i) {


### PR DESCRIPTION
This PR adds the option `--max` can specify a maximum number of rows to parse.
After which the stream pushes null once and filters out everything it consumes.

Thanks for your attention!