### PR TITLE
Rewrite CLI with argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,22 +135,37 @@ $ printf "a,b\nc,d\n" | csv-parser # parses input
 You can specify these CLI flags to control how the input is parsed:
 
 ```
-Usage: csv-parser [filename?] [options]
+usage: csv-parser [-h] [-v] [-s SEPARATOR] [-q QUOTE] [-e ESCAPE]
+                  [--headers HEADERS [HEADERS ...]]
+                  [--remove REMOVE [REMOVE ...]] [--strict]
 
-  --headers,-h        Explicitly specify csv headers as a comma separated list
-  --output,-o         Set output file. Defaults to stdout
-  --separator,-s      Set the separator character ("," by default)
-  --quote,-q          Set the quote character ('"' by default)
-  --escape,-e         Set the escape character (defaults to quote value)
-  --strict            Require column length match headers length
-  --version,-v        Print out the installed version
-  --help              Show this help
+
+Streaming CSV parser that aims for maximum speed as well as compatibility
+with the csv-spectrum test suite. CSV is read from STDIN, formatted to JSON,
+and written to STDOUT.
+
+Optional arguments:
+  -h, --help            Show this help message and exit.
+  -v, --version         Show program's version number and exit.
+  -s SEPARATOR, --separator SEPARATOR
+                        The separator character to use. Defaults to ','.
+  -q QUOTE, --quote QUOTE
+                        The quote character to use. Defaults to '"'.
+  -e ESCAPE, --escape ESCAPE
+                        The escape character to use. Defaults to QUOTE.
+  --headers HEADERS [HEADERS ...]
+                        The list of headers to use. If omitted, the keys of
+                        the first row written to STDIN will be used
+  --remove REMOVE [REMOVE ...]
+                        The list of headers to remove from output. If omitted,
+                         all columnswill be parsed.
+  --strict              Require that column length matches headers length.
 ```
 
 For example, to parse a TSV file:
 
 ```
-cat data.tsv | csv-parser -s $'\t'
+csv-parser -s $'\t' < data.tsv
 ```
 
 ## Related

--- a/bin.js
+++ b/bin.js
@@ -1,74 +1,59 @@
 #!/usr/bin/env node
-
-var minimist = require('minimist')
-var ndjson = require('ndjson')
-var fs = require('fs')
+require('exit-on-epipe')
+var ArgumentParser = require('argparse').ArgumentParser
 var csv = require('./')
+var ndj = require('ndjson')
+var packageInfo = require('./package')
 
-var argv = minimist(process.argv, {
-  alias: {
-    h: 'headers',
-    v: 'version',
-    o: 'output',
-    s: 'separator',
-    q: 'quote',
-    e: 'escape'
-  },
-  default: {
-    s: ',',
-    q: '"',
-    e: '"'
-  },
-  boolean: ['version', 'help']
+var argparser = new ArgumentParser({
+  addHelp: true,
+  description: packageInfo.description + ' CSV is read from STDIN, formatted' +
+  ' to JSON, and written to STDOUT.',
+  version: packageInfo.version
 })
 
-var headers = argv.headers && argv.headers.toString().split(argv.separator)
-var filename = argv._[2]
+argparser.addArgument(['-s', '--separator'], {
+  help: "The separator character to use. Defaults to ','.",
+  defaultValue: ','
+})
+argparser.addArgument(['-q', '--quote'], {
+  help: "The quote character to use. Defaults to '\"'.",
+  defaultValue: '"'
+})
+argparser.addArgument(['-e', '--escape'], {
+  help: 'The escape character to use. Defaults to QUOTE.'
+})
+argparser.addArgument(['--headers'], {
+  nargs: '+',
+  help: 'The list of headers to use. If omitted, the keys of the first row ' +
+  'written to STDIN will be used'
+})
+argparser.addArgument(['--remove'], {
+  nargs: '+',
+  help: 'The list of headers to remove from output. If omitted, all columns' +
+  'will be parsed.'
+})
+argparser.addArgument(['--strict'], {
+  action: 'storeTrue',
+  help: 'Require that column length matches headers length.',
+  defaultValue: false
+})
 
-if (argv.version) {
-  console.log(require('./package').version)
-  process.exit(0)
+var args = argparser.parseArgs()
+
+if (args.escape === null) {
+  args.escape = args.quote
 }
 
-if (argv.help || (process.stdin.isTTY && !filename)) {
-  console.error(
-    'Usage: csv-parser [filename?] [options]\n\n' +
-    '  --headers,-h        Explicitly specify csv headers as a comma separated list\n' +
-    '  --output,-o         Set output file. Defaults to stdout\n' +
-    '  --separator,-s      Set the separator character ("," by default)\n' +
-    '  --quote,-q          Set the quote character (\'"\' by default)\n' +
-    '  --escape,-e         Set the escape character (defaults to quote value)\n' +
-    '  --strict            Require column length match headers length\n' +
-    '  --version,-v        Print out the installed version\n' +
-    '  --remove            Remove headers from output\n' +
-    '  --help              Show this help\n'
-  )
-  process.exit(1)
+var removedHeaders = args.remove
+delete args.remove
+if (removedHeaders) {
+  args.mapHeaders = function (name, i) {
+    return removedHeaders.indexOf(name) === -1 ? name : null
+  }
 }
 
-var input
-var output = (argv.output && argv.output !== '-') ? fs.createWriteStream(argv.output) : process.stdout
-var removedHeaders = argv.remove && argv.remove.split(',')
-
-function mapHeaders (name, i) {
-  return removedHeaders.indexOf(name) === -1 ? name : null
-}
-
-if (filename === '-' || !filename) {
-  input = process.stdin
-} else if (fs.existsSync(filename)) {
-  input = fs.createReadStream(filename)
-} else {
-  console.error('File: %s does not exist', filename)
-  process.exit(2)
-}
-
-input
-  .pipe(csv({
-    headers: headers,
-    separator: argv.separator,
-    strict: argv.strict,
-    mapHeaders: argv.remove ? mapHeaders : null
-  }))
-  .pipe(ndjson.serialize())
-  .pipe(output)
+process.stdin
+  .pipe(csv(args))
+  .pipe(ndj.serialize())
+  .pipe(process.stdout)

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
   "name": "csv-parser",
   "version": "1.11.0",
-  "description": "Streaming CSV parser that aims for maximum speed as well as compatibility with the csv-spectrum test suite",
+  "description": "Streaming CSV parser that aims for maximum speed as well as compatibility with the csv-spectrum test suite.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mafintosh/csv-parser.git"
   },
   "dependencies": {
+    "argparse": "^1.0.7",
+    "exit-on-epipe": "0.0.1",
     "generate-function": "^1.0.1",
     "generate-object-property": "^1.0.0",
     "inherits": "^2.0.1",
-    "minimist": "^1.2.0",
     "ndjson": "^1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I got frustrated with the current CLI & rewrote it...

Right now you need to separate the headers passed via `--headers` with whatever is passed as `--separator`, so it needs to be a tab delimited list if you're working with a TSV, or a pipe delimited list if you're working with any of the BitTorrent tracker site dumps. This doesn't match the `--help` text, which says it's a comma separated list, and none of these match the convention set by the GNU coreutils (space separated lists of args).

Also, it seemed odd that the filename was supposed to be passed before the flag args - usually positional args come last. I ended up getting rid of the filename arg entirely, so rather than passing a file to the CLI, we read everything from STDIN & write to STDOUT. This way we don't need to do `require('fs')` or handle any errors associated with the filesystem.

This PR also fixes handling of EPIPE (when the output is piped into something like `head`), automatically generates the `--help` output, correctly passes the escape arg, and improves the validation of args passed to the CLI.
