### PR TITLE
Allow options "separator", "quote" and "esscape" to be empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ var Parser = function (opts) {
 
   stream.Transform.call(this, {objectMode: true, highWaterMark: 16})
 
-  this.separator = opts.separator ? new Buffer(opts.separator)[0] : comma
-  this.quote = opts.quote ? new Buffer(opts.quote)[0] : quote
-  this.escape = opts.escape ? new Buffer(opts.escape)[0] : this.quote
+  this.separator = typeof opts.separator !== 'undefined' ? new Buffer(opts.separator)[0] : comma
+  this.quote = typeof opts.quote !== 'undefined' ? new Buffer(opts.quote)[0] : quote
+  this.escape = typeof opts.escape !== 'undefined' ? new Buffer(opts.escape)[0] : this.quote
   if (opts.newline) {
     this.newline = new Buffer(opts.newline)[0]
     this.customNewline = true

--- a/test/data/no_escape.csv
+++ b/test/data/no_escape.csv
@@ -1,0 +1,2 @@
+ID|Title|Description
+1|Shirt "Blue" Great|Blue "Shirt" Awsum!

--- a/test/test.js
+++ b/test/test.js
@@ -329,6 +329,16 @@ test('rename columns', function (t) {
   }
 })
 
+test('no escape, no quote', function (t) {
+  collect('no_escape.csv', {quote: '', escape: '', separator: '|'}, verify)
+  function verify (err, lines) {
+    t.false(err, 'no err')
+    t.same(lines[0], {ID: '1', Title: 'Shirt "Blue" Great', Description: 'Blue "Shirt" Awsum!'}, 'first row')
+    t.equal(lines.length, 1, '1 row')
+    t.end()
+  }
+})
+
 // helpers
 
 function fixture (name) {


### PR DESCRIPTION
A little modification allowing said options to be empty. I need this for a ~ 1 million CSV row's read. So it's proven to work. I built a new test for it, too and made sure all other tests are working.
