### PR TITLE
Don't modify input buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ var Parser = function (opts) {
 inherits(Parser, stream.Transform)
 
 Parser.prototype._transform = function (data, enc, cb) {
-  if (typeof data === 'string') data = new Buffer(data)
+  // clone input buffer
+  data = new Buffer(data)
 
   var start = 0
   var buf = data

--- a/test/test.js
+++ b/test/test.js
@@ -329,6 +329,38 @@ test('rename columns', function (t) {
   }
 })
 
+test('doesn\'t modify buffer', function (t) {
+  var inputBuffer = fs.readFileSync(fixture('escaped_quotes.csv'))
+  var parser1 = csv()
+  var parser2 = csv()
+
+  var lines = []
+  parser1.on('data', handleData)
+  parser2.on('data', handleData)
+
+  parser1.on('end', function () {
+    t.same(lines[0], {a: '1', b: 'ha "ha" ha'}, 'first parser, first row')
+    t.same(lines[1], {a: '2', b: '""'}, 'first parser, second row')
+
+    lines = []
+    parser2.write(inputBuffer)
+    parser2.end()
+  })
+
+  parser2.on('end', function () {
+    t.same(lines[0], {a: '1', b: 'ha "ha" ha'}, 'second parser, first row')
+    t.same(lines[1], {a: '2', b: '""'}, 'second parser, second row')
+    t.end()
+  })
+
+  parser1.write(inputBuffer)
+  parser1.end()
+
+  function handleData (line) {
+    lines.push(line)
+  }
+})
+
 // helpers
 
 function fixture (name) {


### PR DESCRIPTION
I was experiencing data corruption which I traced back to my use of [Highland](https://github.com/caolan/highland) and this library. Here's a pared down demonstration:

``` js
'use strict';
const highland = require('highland');
const csv = require('csv-parser');

const input = highland([new Buffer(`column\nsome ""quoted"" string`)]);
const fork1 = input.fork();
const fork2 = input.fork();

fork1.through(csv()).each((x) => { console.log("fork 1:", x); });
fork2.through(csv()).each((x) => { console.log("fork 2:", x); });
```

The output:

```
fork 1: Row { column: 'some "quoted" string' }
fork 2: Row { column: 'some "quoted" stringng' }
```

What's happening is that
1. Highland sends all of its consumers the exact same `Buffer`, and
2. csv-parser rewrites the buffer when it encounters an escape character.

The first Highland fork processes the stream correctly, and the second gets a corrupt `Buffer` and produces corrupt output.

With this PR, the incoming buffer is cloned before any modifications are made. There doesn't seem to be any impact on benchmark speed (I initially tried cloning each cell `Buffer`, and that did cause a slowdown). There is a test case in the PR which demonstrates the issue without reference to Highland.
