### PR TITLE
add mapValues, which mirrors mapHeaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ var Parser = function (opts) {
 
   this.headers = opts.headers || null
   this.strict = opts.strict || null
-  this.mapHeaders = opts.mapHeaders || defaultMapHeaders
+  this.mapHeaders = opts.mapHeaders || identity
+  this.mapValues = opts.mapValues || identity
 
   this._raw = !!opts.raw
   this._prev = null
@@ -207,7 +208,8 @@ Parser.prototype._oncell = function (buf, start, end) {
     y++
   }
 
-  return this._onvalue(buf, start, y)
+  var value = this._onvalue(buf, start, y)
+  return this._first ? value : this.mapValues(value)
 }
 
 Parser.prototype._onvalue = function (buf, start, end) {
@@ -215,7 +217,7 @@ Parser.prototype._onvalue = function (buf, start, end) {
   return buf.toString('utf-8', start, end)
 }
 
-function defaultMapHeaders (id) {
+function identity (id) {
   return id
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -332,7 +332,6 @@ test('rename columns', function (t) {
 test('format values', function (t) {
   collect('dummy.csv', {mapValues: mapValues}, verify)
   function mapValues (v) {
-    console.log(v)
     return parseInt(v, 10)
   }
   function verify (err, lines) {

--- a/test/test.js
+++ b/test/test.js
@@ -329,6 +329,20 @@ test('rename columns', function (t) {
   }
 })
 
+test('format values', function (t) {
+  collect('dummy.csv', {mapValues: mapValues}, verify)
+  function mapValues (v) {
+    console.log(v)
+    return parseInt(v, 10)
+  }
+  function verify (err, lines) {
+    t.false(err, 'no err')
+    t.same(lines[0], {a: 1, b: 2, c: 3}, 'first row')
+    t.equal(lines.length, 1, '1 row')
+    t.end()
+  }
+})
+
 // helpers
 
 function fixture (name) {


### PR DESCRIPTION
- Test added
- Usage mirrors mapHeaders
-  No increase in time for the benchmarks.

This is extremely useful for doing parsing (strings to numbers, dates, etc.) efficiently.

Thanks!