### PR TITLE
Set error name to SyntaxError

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,9 @@ Parser.prototype._online = function (buf, start, end) {
   }
 
   if (this.strict && cells.length !== this.headers.length) {
-    this.emit('error', new Error('Row length does not match headers'))
+    var e = new Error('Row length does not match headers')
+    e.name = 'SyntaxError'
+    this.emit('error', e)
   } else {
     this._emit(this._Row, cells)
   }

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,12 @@
 var test = require('tape')
 var fs = require('fs')
 var path = require('path')
-var eol = require('os').EOL
 var bops = require('bops')
 var spectrum = require('csv-spectrum')
 var concat = require('concat-stream')
 var csv = require('..')
 var read = fs.createReadStream
+var eol = '\n'
 
 test('simple csv', function (t) {
   collect('dummy.csv', verify)
@@ -235,7 +235,8 @@ test('custom newline', function (t) {
 test('optional strict', function (t) {
   collect('test_strict.csv', {strict: true}, verify)
   function verify (err, lines) {
-    t.equal(err.message, 'Row length does not match headers', 'strict row length')
+    t.equal(err.name, 'SyntaxError', 'err name')
+    t.equal(err.message, 'Row length does not match headers', 'err message')
     t.same(lines[0], {a: '1', b: '2', c: '3'}, 'first row')
     t.same(lines[1], {a: '4', b: '5', c: '6'}, 'second row')
     t.equal(lines.length, 2, '2 rows before error')


### PR DESCRIPTION
Changed the name of the error that the parser emits from the default of `Error` to `SyntaxError`. This makes it easier for users to distinguish parsing errors from other error types. This also makes the parser behave more like `JSON.parse()`, which emits a `SyntaxError` when it encounters invalid JSON.

See the following for details on `Error.name`:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name