### PR TITLE
Ignore test csv's EOL

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,15 @@
 var test = require('tape')
 var fs = require('fs')
 var path = require('path')
-var eol = require('os').EOL
 var bops = require('bops')
 var spectrum = require('csv-spectrum')
 var concat = require('concat-stream')
 var csv = require('..')
 var read = fs.createReadStream
+
+var eol = fs.readFileSync(path.join(__dirname, 'data', 'dummy.csv')).includes('\r\n')
+        ? '\r\n'
+        : '\n'
 
 test('simple csv', function (t) {
   collect('dummy.csv', verify)


### PR DESCRIPTION
Makes the test suite work, even if fixture csv files EOL does not match system EOL. This can happen, if .tgz release is used to run tests on Windows - like used in https://github.com/nodejs/citgm