### PR TITLE
Compile README.md w/ documentary

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ npm install csv-parser
 
 `csv-parser` can convert CSV into JSON at at rate of around 90,000 rows per second (perf varies with data, try `bench.js` with your data).
 
+## Table Of Contents
+
+- [Table Of Contents](#table-of-contents)
+- [Usage](#usage)
+- [Events](#events)
+  * [data](#data)
+  * [headers](#headers)
+  * [Other Readable Stream Events](#other-readable-stream-events)
+- [Command Line Tool](#command-line-tool)
+  * [Options](#options)
+- [Related](#related)
+- [License](#license)
+
 ## Usage
 
 Simply instantiate `csv` and pump a csv file to it and get the rows out as objects
@@ -19,30 +32,35 @@ You can use `csv-parser` in the browser with [browserify](http://browserify.org/
 
 Let's say that you have a CSV file ``some-csv-file.csv`` like this:
 
-```
-NAME, AGE
-Daffy Duck, 24
-Bugs Bunny, 22
+```csv
+NAME,AGE
+Daffy Duck,24
+Bugs Bunny,22
 ```
 
 You can parse it like this:
 
-``` js
+```js
 var csv = require('csv-parser')
 var fs = require('fs')
 
-fs.createReadStream('some-csv-file.csv')
+fs.createReadStream('example/some-csv-file.csv')
   .pipe(csv())
   .on('data', function (data) {
     console.log('Name: %s Age: %s', data.NAME, data.AGE)
   })
 ```
 
+```
+Name: Daffy Duck Age: 24
+Name: Bugs Bunny Age: 22
+```
+
 The data emitted is a normalized JSON object. Each header is used as the property name of the object.
 
 The csv constructor accepts the following options as well
 
-``` js
+```js
 var stream = csv({
   raw: false,     // do not decode to utf-8 strings
   separator: ',', // specify optional cell separator
@@ -52,28 +70,33 @@ var stream = csv({
   strict: true    // require column length match headers length
 })
 ```
+
 It accepts too an array, that specifies the headers for the object returned:
 
-``` js
+```js
 var stream = csv(['index', 'message'])
 
-// Source from somewere with format 12312,Hello World
+// Source from somewhere with format 12312,Hello World
 origin.pipe(stream)
   .on('data', function (data) {
-    console.log(data) // Should output { "index": 12312, "message": "Hello World" }
+    console.log(data)
   })
+```
+
+```
+Row { index: '12312', message: 'Hello World' }
 ```
 
 or in the option object as well
 
-``` js
+```js
 var stream = csv({
   raw: false,     // do not decode to utf-8 strings
   separator: ',', // specify optional cell separator
   quote: '"',     // specify optional quote character
   escape: '"',    // specify optional escape character (defaults to quote value)
   newline: '\n',  // specify a newline character
-  headers: ['index', 'message'] // Specifing the headers
+  headers: ['index', 'message'] // Specifying the headers
 })
 ```
 
@@ -93,29 +116,42 @@ For each row parsed (except the header), this event is emitted. This is already 
 
 After the header row is parsed this event is emitted. An array of header names is supplied as the payload.
 
-```
-fs.createReadStream('some-csv-file.csv')
+```js
+fs.createReadStream('example/some-csv-file.csv')
   .pipe(csv())
   .on('headers', function (headerList) {
     console.log('First header: %s', headerList[0])
   })
 ```
 
+```
+First header: NAME
+```
+
 ### Other Readable Stream Events
+
 The usual [Readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) events are also emitted. Use the ``close`` event to detect the end of parsing.
 
-```
-fs.createReadStream('some-csv-file.csv')
+```js
+fs.createReadStream('example/some-csv-file.csv')
   .pipe(csv())
   .on('data', function (data) {
     // Process row
+    console.log('data event')
   })
   .on('end', function () {
     // We are done
-})
+    console.log('end event')
+  })
 ```
 
-## Command line tool
+```
+data event
+data event
+end event
+```
+
+## Command Line Tool
 
 There is also a command line tool available. It will convert csv to line delimited JSON.
 
@@ -144,6 +180,7 @@ Usage: csv-parser [filename?] [options]
   --escape,-e         Set the escape character (defaults to quote value)
   --strict            Require column length match headers length
   --version,-v        Print out the installed version
+  --remove            Remove headers from output
   --help              Show this help
 ```
 

--- a/documentary/1-usage.md
+++ b/documentary/1-usage.md
@@ -1,0 +1,36 @@
+
+## Usage
+
+Simply instantiate `csv` and pump a csv file to it and get the rows out as objects
+
+You can use `csv-parser` in the browser with [browserify](http://browserify.org/)
+
+Let's say that you have a CSV file ``some-csv-file.csv`` like this:
+
+%EXAMPLE: example/some-csv-file.csv%
+
+You can parse it like this:
+
+%EXAMPLE: example/parse.js, .. => csv-parser%
+
+%FORK example/parse%
+
+The data emitted is a normalized JSON object. Each header is used as the property name of the object.
+
+The csv constructor accepts the following options as well
+
+%EXAMPLE: example/constructor.js%
+
+It accepts too an array, that specifies the headers for the object returned:
+
+%EXAMPLE: example/array.js, .. => csv-parser%
+
+%FORK example/array%
+
+or in the option object as well
+
+%EXAMPLE: example/array-options.js%
+
+If you do not specify the headers, csv-parser will take the first line of the csv and treat it like the headers.
+
+Another issue might be the encoding of the source file. Transcoding the source stream can be done neatly with something like [`iconv-lite`](https://www.npmjs.com/package/iconv-lite), Node bindings to [`iconv`](https://www.npmjs.com/package/iconv) or native [`iconv`](http://man7.org/linux/man-pages/man1/iconv.1.html) if part of a pipeline.

--- a/documentary/2-events/1-data.md
+++ b/documentary/2-events/1-data.md
@@ -1,0 +1,4 @@
+
+### data
+
+For each row parsed (except the header), this event is emitted. This is already discussed above.

--- a/documentary/2-events/2-headers.md
+++ b/documentary/2-events/2-headers.md
@@ -1,0 +1,8 @@
+
+### headers
+
+After the header row is parsed this event is emitted. An array of header names is supplied as the payload.
+
+%EXAMPLE: example/events/headers.js, ../.. => csv-parser%
+
+%FORK example/events/headers%

--- a/documentary/2-events/3-other.md
+++ b/documentary/2-events/3-other.md
@@ -1,0 +1,8 @@
+
+### Other Readable Stream Events
+
+The usual [Readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) events are also emitted. Use the ``close`` event to detect the end of parsing.
+
+%EXAMPLE: example/events/other.js, ../.. => csv-parser%
+
+%FORK example/events/other%

--- a/documentary/2-events/index.md
+++ b/documentary/2-events/index.md
@@ -1,0 +1,4 @@
+
+## Events
+
+The following events are emitted during parsing.

--- a/documentary/3-cli.md
+++ b/documentary/3-cli.md
@@ -1,0 +1,27 @@
+
+## Command Line Tool
+
+There is also a command line tool available. It will convert csv to line delimited JSON.
+
+```
+npm install -g csv-parser
+```
+
+Open a shell and run
+
+```
+$ csv-parser --help # prints all options
+$ printf "a,b\nc,d\n" | csv-parser # parses input
+```
+
+### Options
+
+You can specify these CLI flags to control how the input is parsed:
+
+%FORKERR bin --help%
+
+For example, to parse a TSV file:
+
+```
+cat data.tsv | csv-parser -s $'\t'
+```

--- a/documentary/footer.md
+++ b/documentary/footer.md
@@ -1,0 +1,8 @@
+
+## Related
+
+- [neat-csv](https://github.com/sindresorhus/neat-csv) - Promise convenience wrapper
+
+## License
+
+MIT

--- a/documentary/index.md
+++ b/documentary/index.md
@@ -1,0 +1,16 @@
+# csv-parser
+
+Streaming CSV parser that aims for maximum speed as well as compatibility with the [csv-spectrum](https://npmjs.org/csv-spectrum) CSV acid test suite
+
+```
+npm install csv-parser
+```
+
+[![build status](http://img.shields.io/travis/mafintosh/csv-parser.svg?style=flat)](http://travis-ci.org/mafintosh/csv-parser)
+![dat](http://img.shields.io/badge/Development%20sponsored%20by-dat-green.svg?style=flat)
+
+`csv-parser` can convert CSV into JSON at at rate of around 90,000 rows per second (perf varies with data, try `bench.js` with your data).
+
+## Table Of Contents
+
+%TOC%

--- a/example/array-options.js
+++ b/example/array-options.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-unused-vars */
+var csv = require('..')
+
+/* start example */
+var stream = csv({
+  raw: false,     // do not decode to utf-8 strings
+  separator: ',', // specify optional cell separator
+  quote: '"',     // specify optional quote character
+  escape: '"',    // specify optional escape character (defaults to quote value)
+  newline: '\n',  // specify a newline character
+  headers: ['index', 'message'] // Specifying the headers
+})
+/* end example */

--- a/example/array.js
+++ b/example/array.js
@@ -1,0 +1,19 @@
+var csv = require('..')
+var s = require('stream')
+var Readable = s.Readable
+
+var origin = new Readable({
+  read: function () {
+    this.push('12312,Hello World')
+    this.push(null)
+  }
+})
+/* start example */
+var stream = csv(['index', 'message'])
+
+// Source from somewhere with format 12312,Hello World
+origin.pipe(stream)
+  .on('data', function (data) {
+    console.log(data)
+  })
+/* end example */

--- a/example/constructor.js
+++ b/example/constructor.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-unused-vars */
+var csv = require('..')
+
+/* start example */
+var stream = csv({
+  raw: false,     // do not decode to utf-8 strings
+  separator: ',', // specify optional cell separator
+  quote: '"',     // specify optional quote character
+  escape: '"',    // specify optional escape character (defaults to quote value)
+  newline: '\n',  // specify a newline character
+  strict: true    // require column length match headers length
+})
+/* end example */

--- a/example/events/headers.js
+++ b/example/events/headers.js
@@ -1,0 +1,10 @@
+var csv = require('../..')
+var fs = require('fs')
+
+/* start example */
+fs.createReadStream('example/some-csv-file.csv')
+  .pipe(csv())
+  .on('headers', function (headerList) {
+    console.log('First header: %s', headerList[0])
+  })
+/* end example */

--- a/example/events/other.js
+++ b/example/events/other.js
@@ -1,0 +1,15 @@
+var csv = require('../..')
+var fs = require('fs')
+
+/* start example */
+fs.createReadStream('example/some-csv-file.csv')
+  .pipe(csv())
+  .on('data', function (data) {
+    // Process row
+    console.log('data event')
+  })
+  .on('end', function () {
+    // We are done
+    console.log('end event')
+  })
+/* end example */

--- a/example/parse.js
+++ b/example/parse.js
@@ -1,0 +1,8 @@
+var csv = require('..')
+var fs = require('fs')
+
+fs.createReadStream('example/some-csv-file.csv')
+  .pipe(csv())
+  .on('data', function (data) {
+    console.log('Name: %s Age: %s', data.NAME, data.AGE)
+  })

--- a/example/some-csv-file.csv
+++ b/example/some-csv-file.csv
@@ -1,0 +1,3 @@
+NAME,AGE
+Daffy Duck,24
+Bugs Bunny,22

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "bops": "^0.1.1",
     "concat-stream": "^1.4.5",
     "csv-spectrum": "^1.0.0",
+    "documentary": "^1.13.0",
     "standard": "^5.4.1",
     "tape": "^4.2.2"
   },
@@ -26,7 +27,8 @@
     "csv-parser": "./bin.js"
   },
   "scripts": {
-    "test": "standard && tape test/test.js"
+    "test": "standard && tape test/test.js",
+    "doc": "NODE_DEBUG=doc doc documentary -o README.md"
   },
   "keywords": [
     "csv",


### PR DESCRIPTION
[`documentary`](/artdecocoe/documentary) is a documentation pre-processor which allows to embed examples and fork them to include the output in the README. It's much better than copying and pasting by hand, because it will also make visible when an example does not actually work, or hasn't been updated (e.g., the `--remove` option in the CLI in this PR).

I hope you like it and it'd be great if this package could be one of the first 3-rd party software which uses it!