### PR TITLE
Include typescript declaration file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "main": "index.js",
   "files": [
     "bin/csv-parser",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "engines": {
     "node": ">= 6.14.0"


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [x] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Upon trying your library I was getting `Could not find a declaration file for module 'csv-parser'.` Noticed it wasn't included in the `package.json`. Typescript couldn't find the declaration file from #97 
