### PR TITLE
fixed false key escape caused by byte order mark.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const genobj = require('generate-object-property')
 const genfun = require('generate-function')
 const bufferFrom = require('buffer-from')
 const bufferAlloc = require('buffer-alloc')
+const isUtf8 = require('is-utf8')
 
 const [cr] = bufferFrom('\r')
 const [nl] = bufferFrom('\n')
@@ -199,6 +200,14 @@ class CsvParser extends Transform {
   }
 
   _transform (data, enc, cb) {
+    // is it UTF8?
+    if (isUtf8(data)) {
+      // is it encoded w/ BOM? (BOM or byte order mark = 0xFEFF)
+      if (data[0] === 0xef && data[1] === 0xbb && data[2] === 0xbf) {
+        // get rid of BOM
+        data = data.slice(3)
+      }
+    }
     if (typeof data === 'string') data = bufferFrom(data)
 
     let start = 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -5493,8 +5493,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "execa": "^1.0.0",
     "generate-function": "^1.0.1",
     "generate-object-property": "^1.0.0",
+    "is-utf8": "^0.2.1",
     "minimist": "^1.2.0",
     "ndjson": "^1.4.0"
   },


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove this template, or parts of it, your Pull Request WILL be closed.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes
Fix for #79
"UTF8 with BOM" encoding causes unwanted key name escape.
<!--
  Please be thorough.
  What existing problem does the PR solve?
  Does this PR resolve an issue?
-->
