### PR TITLE
fix: make tests compatible with Node.js -pre releases

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -242,7 +242,7 @@ test.cb('process all rows', (t) => {
 
 test('binary stanity', async (t) => {
   const binPath = path.resolve(__dirname, '../bin/csv-parser')
-  const { stdout } = await execa(`echo "a\n1" | node ${binPath}`, { shell: true })
+  const { stdout } = await execa.node(binPath, { input: 'a\n1' })
 
   t.snapshot(stdout)
 })


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove this template, or parts of it, your Pull Request WILL be closed.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains:

- [x] bugfix
- [x] refactor
- [x] tests

### Breaking Changes?

- [ ] yes
- [x] no

### Please Describe Your Changes

<!--
  Please be thorough.
  What existing problem does the PR solve?
  Does this PR resolve an issue?
-->

I don't know why, but `execa.node()` with the `input` option works with
Node.js -pre releases where the current configuration fails. This has
the benefit of making sure that the test is run with the version of
Node.js currently being used to execute the test suite, rather than
whatever is first in the user's path.

Before, with Node.js 13.0.0-pre:

```
$ ~/io.js/node node_modules/.bin/ava test/test.js

  1 test failed

  binary stanity

  /Users/trott/temp/csv-parser/test/test.js:247

   246:
   247:   t.snapshot(stdout)
   248: })

  Did not match snapshot

  Difference:

  - ''
  + '{"a":"1"}'
$
```

FWIW, this means that the test fails with CITGM run against the Node.js master branch.

This is somewhat strange because the offending commit in Node.js to be removed to fix this would seem to be ones like this: https://github.com/nodejs/node/commit/bbbe07a4475b06b9295007c6f5bcefb5ba1431e5 I imagine the issue is somewhere inside `execa` but I'm not 100% sure. Nonetheless, I *think* this is a better/more-clear/less-brittle way to write the particular line?
