### PR TITLE
chore: use `process.execPath` rather than `node` in test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -242,7 +242,7 @@ test.cb('process all rows', (t) => {
 
 test('binary stanity', async (t) => {
   const binPath = path.resolve(__dirname, '../bin/csv-parser')
-  const { stdout } = await execa(`echo "a\n1" | node ${binPath}`, { shell: true })
+  const { stdout } = await execa(`echo "a\n1" | ${process.execPath} ${binPath}`, { shell: true })
 
   t.snapshot(stdout)
 })


### PR DESCRIPTION


<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove this template, or parts of it, your Pull Request WILL be closed.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [x] refactor
- [x] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Make sure that the test is run with the version of Node.js currently
being used to execute the test suite, rather than whatever is first in
the user's path.

<!--
  Please be thorough.
  What existing problem does the PR solve?
  Does this PR resolve an issue?
-->
