### PR TITLE
refactor: prefer builtin Buffer utils over ponyfills

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 const { Transform } = require('stream')
-const bufferFrom = require('buffer-from')
-const bufferAlloc = require('buffer-alloc')
 
-const [cr] = bufferFrom('\r')
-const [nl] = bufferFrom('\n')
+const [cr] = Buffer.from('\r')
+const [nl] = Buffer.from('\n')
 const defaults = {
   escape: '"',
   headers: null,
@@ -31,15 +29,15 @@ class CsvParser extends Transform {
 
     for (const key of ['newline', 'quote', 'separator']) {
       if (typeof options[key] !== 'undefined') {
-        ([options[key]] = bufferFrom(options[key]))
+        ([options[key]] = Buffer.from(options[key]))
       }
     }
 
     // if escape is not defined on the passed options, use the end value of quote
-    options.escape = (opts || {}).escape ? bufferFrom(options.escape)[0] : options.quote
+    options.escape = (opts || {}).escape ? Buffer.from(options.escape)[0] : options.quote
 
     this.state = {
-      empty: options.raw ? bufferAlloc(0) : '',
+      empty: options.raw ? Buffer.alloc(0) : '',
       escaped: false,
       first: true,
       lineNumber: 0,
@@ -103,7 +101,7 @@ class CsvParser extends Transform {
 
     if (skipComments) {
       const char = typeof skipComments === 'string' ? skipComments : '#'
-      if (buffer[start] === bufferFrom(char)[0]) {
+      if (buffer[start] === Buffer.from(char)[0]) {
         return
       }
     }
@@ -201,7 +199,7 @@ class CsvParser extends Transform {
 
   _transform (data, enc, cb) {
     if (typeof data === 'string') {
-      data = bufferFrom(data)
+      data = Buffer.from(data)
     }
 
     const { escape, quote } = this.options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1549,29 +1549,11 @@
         "fill-range": "^7.0.1"
       }
     },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "test": "ava && tsd"
   },
   "dependencies": {
-    "buffer-alloc": "^1.1.0",
-    "buffer-from": "^1.0.0",
     "minimist": "^1.2.0",
     "through2": "^3.0.1"
   },


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove this template, or parts of it, your Pull Request WILL be closed.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

I see builtin buffer utils were not used because of old node support.
Though they are dropped now. And there is no need in these dependencies.

https://github.com/mafintosh/csv-parser/pull/83#issuecomment-377797828

Though I hope this change will not recover this problem.

https://github.com/mafintosh/csv-parser/issues/81
