### PR TITLE
Chore(docs): fix "it's"/"its" mistake

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ Bugs Bunny,22
     readonly headers?: ReadonlyArray<string> | boolean;
 
     /**
-     * A function that can be used to modify the values of each header. Return `null` to remove the header, and it's column, from the results.
+     * A function that can be used to modify the values of each header. Return `null` to remove the header, and its column, from the results.
      *
      * @example
      *


### PR DESCRIPTION
Replace the mistaken "it's" with the correct "its"

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove this template, or parts of it, your Pull Request WILL be closed.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

In the `mapHeaders` function's JSDoc documentation, replace the incorrect *it's* with the correct *its*.

(at `csvParser.Options['mapHeaders']`)

<!--
  Please be thorough.
  What existing problem does the PR solve?
  Does this PR resolve an issue?
-->
