### PR TITLE
feat: support multi-character separators

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
   "ava": {
     "files": [
       "!**/fixtures/**",
-      "!**/helpers/**"
+      "!**/helpers/**",
+      "test/*.test.js"
     ]
   },
   "husky": {

--- a/test/fixtures/multi-separator.csv
+++ b/test/fixtures/multi-separator.csv
@@ -1,0 +1,4 @@
+nombre#|#edad#|#ciudad
+Juan#|#25#|#Madrid
+Ivan#|#30#|#Barcelona
+Luis#|#28#|#Valencia

--- a/test/multicharSeparator.test.js
+++ b/test/multicharSeparator.test.js
@@ -1,0 +1,25 @@
+const test = require('ava');
+const fs = require('fs');
+const path = require('path');
+const csv = require('../');
+const { Readable } = require('stream');
+
+test('parse CSV with multi-character separator', async (t) => {
+  const filePath = path.join(__dirname, 'fixtures', 'multi-separator.csv');
+  const input = fs.createReadStream(filePath);
+
+  const results = [];
+  return new Promise((resolve) => {
+    input
+      .pipe(csv({ separator: '#|#' }))
+      .on('data', (data) => results.push(data))
+      .on('end', () => {
+        t.deepEqual(results, [
+          { nombre: 'Juan', edad: '25', ciudad: 'Madrid' },
+          { nombre: 'Ivan', edad: '30', ciudad: 'Barcelona' },
+          { nombre: 'Luis', edad: '28', ciudad: 'Valencia' },
+        ]);
+        resolve();
+      });
+  });
+});

--- a/test/multicharSeparator.test.js
+++ b/test/multicharSeparator.test.js
@@ -1,14 +1,13 @@
-const test = require('ava');
-const fs = require('fs');
-const path = require('path');
-const csv = require('../');
-const { Readable } = require('stream');
+const test = require('ava')
+const fs = require('fs')
+const path = require('path')
+const csv = require('../')
 
 test('parse CSV with multi-character separator', async (t) => {
-  const filePath = path.join(__dirname, 'fixtures', 'multi-separator.csv');
-  const input = fs.createReadStream(filePath);
+  const filePath = path.join(__dirname, 'fixtures', 'multi-separator.csv')
+  const input = fs.createReadStream(filePath)
 
-  const results = [];
+  const results = []
   return new Promise((resolve) => {
     input
       .pipe(csv({ separator: '#|#' }))
@@ -17,9 +16,9 @@ test('parse CSV with multi-character separator', async (t) => {
         t.deepEqual(results, [
           { nombre: 'Juan', edad: '25', ciudad: 'Madrid' },
           { nombre: 'Ivan', edad: '30', ciudad: 'Barcelona' },
-          { nombre: 'Luis', edad: '28', ciudad: 'Valencia' },
-        ]);
-        resolve();
-      });
-  });
-});
+          { nombre: 'Luis', edad: '28', ciudad: 'Valencia' }
+        ])
+        resolve()
+      })
+  })
+})


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove this template, or parts of it, your Pull Request WILL be closed.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

This PR adds support for multi-character separators in csv-parser.
- `parseLine()` now correctly detects and processes multi-character separators.
- Fixed an issue where `separator` was converted to a number in `Buffer.from()`.
- Added tests in `test/multicharSeparator.test.js` to validate the feature.
- Included a sample CSV file in `test/fixtures/multi-separator.csv`.

<!--
  Please be thorough.
  What existing problem does the PR solve?
  Does this PR resolve an issue?
-->
